### PR TITLE
[BLOCK-570] - Use correct docker image and expand failure exit message

### DIFF
--- a/scripts/docker/start_docker.sh
+++ b/scripts/docker/start_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # set -x
 
-IMAGE=${1:-"ultra-dev:latest"}
+IMAGE=${1:-"quay.io/ultra.io/3rdparty-devtools:latest"}
 NAME=ultra-dev-environment
 
 case "$OSTYPE" in
@@ -37,6 +37,6 @@ else
   winpty docker exec -it ultra-dev-environment bash
 fi
 
-echo "Docker Image is still running with name 'ultra-dev-environment' please use 'stop_docker.sh' to stop the container."
+echo "Docker Image is still potentially running with name 'ultra-dev-environment' please use 'stop_docker.sh' to stop the container. Or some other process already uses the port 8888 or 9876"
 
 exit 0


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Jira ticket
[BLOCK-570](https://ultraio.atlassian.net/browse/BLOCK-570)

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Updates default docker start script image URL to use latest tag